### PR TITLE
fix: guard against empty pull_requests list in check_run/check_suite events

### DIFF
--- a/chronographer/event_handlers.py
+++ b/chronographer/event_handlers.py
@@ -108,13 +108,15 @@ async def on_pr(event):
     if event.event == 'pull_request':
         pull_request = event.data['pull_request']
     elif event.event == 'check_run':
-        pull_request = (
-            event.data['check_run']['check_suite']['pull_requests'][0]
-        )
+        prs = event.data['check_run']['check_suite']['pull_requests']
+        if not prs:
+            return
+        pull_request = prs[0]
     elif event.event == 'check_suite':
-        pull_request = (
-            event.data['check_suite']['pull_requests'][0]
-        )
+        prs = event.data['check_suite']['pull_requests']
+        if not prs:
+            return
+        pull_request = prs[0]
     pr_author = pull_request['user']
     pr_labels = {label['name'] for label in pull_request['labels']}
     diff_url = (

--- a/chronographer/event_handlers.py
+++ b/chronographer/event_handlers.py
@@ -121,7 +121,7 @@ async def on_pr(event):
     pr_labels = {label['name'] for label in pull_request['labels']}
     diff_url = (
         f'https://github.com/{repo_slug}'
-        f'/pull/{pull_request["number"]:d}.diff'
+        f'/pull/{pull_request['number']:d}.diff'
     )
     head_branch = pull_request['head']['ref']
     head_sha = pull_request['head']['sha']
@@ -189,7 +189,7 @@ async def on_pr(event):
                         'title':
                             f'{checks_summary_title_prefix!s}'
                             'Nothing to do — change note not required',
-                        'text': f'Labels: {", ".join(pr_labels)}',
+                        'text': f'Labels: {', '.join(pr_labels)}',
                         'summary':
                             'Heeeeey!'
                             '\n\n'
@@ -268,7 +268,7 @@ async def on_pr(event):
         'Check run ID is %s',
         resp['id'],
     )
-    check_runs_updates_uri = f'{check_runs_base_uri}/{resp["id"]:d}'
+    check_runs_updates_uri = f'{check_runs_base_uri}/{resp['id']:d}'
 
     logger.info("Here's the diff URL: %s", diff_url)
     diff_text = await gh_api.getitem(
@@ -317,7 +317,7 @@ async def on_pr(event):
     )
 
     if news_fragments_added and fragment_provided_label is not None:
-        labels_url = f'{pull_request["issue_url"]}/labels'
+        labels_url = f'{pull_request['issue_url']}/labels'
         await gh_api.post(
             labels_url,
             preview_api_version='symmetra',


### PR DESCRIPTION
## Summary

When a `check_run` or `check_suite` webhook event has an empty `pull_requests` array, accessing `[0]` raises `IndexError: list index out of range`. This can happen when a check suite is created without an associated PR (e.g., on a push to a branch without an open PR).

## Fix

Add a guard check in both the `check_run` and `check_suite` branches of `on_pr()`: if `pull_requests` is empty, return early instead of crashing.

Fixes #53